### PR TITLE
Updated the website for 2023 Econference

### DIFF
--- a/about.html
+++ b/about.html
@@ -112,7 +112,7 @@
 			-->
 			
 			<div class='demo-container'>
-				<div class='carousel'>
+				<div id='carousel1' class='carousel'>
 				  <input class='carousel__activator' type='radio' checked id='carousel-slide-activator-1' name='carousel'>
 				  <input class='carousel__activator' type='radio' id='carousel-slide-activator-2' name='carousel'>
 				  <input class='carousel__activator' type='radio' id='carousel-slide-activator-3' name='carousel'>

--- a/about.html
+++ b/about.html
@@ -209,7 +209,7 @@
 							</a>
 							
 						</div>
-						<p class='name'>Sophia Lang</p>
+						<p class='name'>Sophia Liang</p>
 						<p class='title'>VP Finance</p>
 					  </div>
 					  <div class='carousel__item carousel__item--mobile-in-1 carousel__item--tablet-in-2 carousel__item--desktop-in-3'>

--- a/econference.html
+++ b/econference.html
@@ -136,14 +136,14 @@
 								Attire is business professional, and food will be provided.
 							</p>
 							<br><span class="image right"><img src="images/w18efattend.JPG"></span><br>
-							ECONference is on <strong>Saturday, April 23rd, 2022 from 4:00 to 7:45pm</strong> in the <strong>SSC Multipurpose Room</strong>.<br><br>
-					  You can register on this <a href="https://www.eventbrite.com/e/playing-now-econference-tickets-317209049807"> Eventbrite page here!</a>
-					  <br><br>For more information and updates, be sure to follow our <a href="https://instagram.com/ues_ucsd?igshid=YmMyMTA2M2Y="> Instagram </a> page!
-					<br><br><br><br>
+							<h3><strong>The location and time for 2023 Econference will be announced soon!</strong></h3><br><br>
+					  <!--You can register on this <a href="https://www.eventbrite.com/e/playing-now-econference-tickets-317209049807"> Eventbrite page here!</a>-->
+					  For more information and updates, be sure to follow our <a href="https://instagram.com/ues_ucsd?igshid=YmMyMTA2M2Y="> Instagram </a> page!
+					<br><br><br><br><br><br>
 
 </p>
 <br>		
-					<hr>
+					<!--<hr>
 
 					<h2> Speaker Highlights </h2>
 
@@ -157,7 +157,7 @@
 					<!-- <span class="image left"><img src="images/econf19/ryan.png"></span>
 					<p style="font-size:17px;color:black">
 					<h1>Sophia Luo</h1><br> Sophia is currently a Senior Associate at Insight Economics. Sophia is a UCSD alumni, graduating in 2019 with a B.S. in Management Science with a minor in accounting. She was involved on campus in Lumnus Consulting.
-					</p>  -->
+					</p>  
 
 					<br> 
 					<span class="image left"><img src="images/vincent.jpeg"></span>
@@ -169,7 +169,7 @@
 					<span class="image left"><img src="images/econf19/ryan.png"></span>
 					<p style="font-size:17px;color:black">
 					<h1>Ryan Kuriakose</h1><br> Ryan is currently a senior at UCSD, majoring in Joint Mathematics-Economics. He has completed two internships in investment banking and finance, and was involved on campus as the VP Finance of Delta Sigma Pi.
-					</p> -->
+					</p> 
 
 					<br><br><br> 
 
@@ -311,7 +311,7 @@
 						  dots[slideIndex-1].className += " active";
 						  setTimeout(showSlides, 5000); // Change image every 2 seconds
 						}
-						</script>
+						</script>-->
 
 
 				</div>

--- a/events.html
+++ b/events.html
@@ -78,7 +78,7 @@
 				-->
 				<div class="6u 12u$(xsmall)">
 								<div class="image fit captioned">
-								</font size = "6"><a href="econference.html">TBA!</a></font>
+								<a style = "font-size: 4em; color:black;"  href="econference.html">TBA!</a>
 								<h3>Econference 2023</h3>
 								</div>
                             </div>               				 

--- a/events.html
+++ b/events.html
@@ -70,17 +70,18 @@
 					</div>
 				</div>
 				-->
-				<div class="6u 12u$(xsmall)">
+				<!--div class="6u 12u$(xsmall)">
 					<div class="image fit captioned">
 						<a href="recruitment.html"><img src="images\media22-23\Updated_Recruitment_Banner.png" /><h3>Fall 2022 Recruitment</h3></a>
 					</div>
 				</div>
-				<!-- <div class="6u 12u$(xsmall)">
+				-->
+				<div class="6u 12u$(xsmall)">
 								<div class="image fit captioned">
-								<a href="econference.html"><img src="images/flyers/ExternshipFlyerHead.jpeg"/></a>
-								<h3>Econference 2022</h3>
+								</font size = "6"><a href="econference.html">TBA!</a></font>
+								<h3>Econference 2023</h3>
 								</div>
-                            </div>               				 -->
+                            </div>               				 
 			</div>
 	</section>
 	<!-- Footer -->


### PR DESCRIPTION
Removed the 2022 externship card on the events page.
Added the 2023 Econference card on that page.
Removed the previous image on the Econference card.
Commented out the speaker information from the 2022 Econference on the Econference page, and removed the 2022 Econference time and location as well as the Eventbrite link.